### PR TITLE
Fix moq-telemetry-pub async bug

### DIFF
--- a/moq-telemetry-pub/src/media.rs
+++ b/moq-telemetry-pub/src/media.rs
@@ -56,7 +56,7 @@ impl Media {
 			//log::debug!("segment: {:?}", segment);
 
 			//wait one second
-    		thread::sleep(Duration::from_millis(1000));
+    		tokio::time::sleep(Duration::from_millis(1000)).await;
 		}
 	}
 }


### PR DESCRIPTION
We need something in `media.run()` to yield (e.g. by `.await`-ing) otherwise the `tokio::select! { }` in main.rs will never drive `session.run()`

This is something I ran into when I was first learning how to do async Rust, too:
- https://mikeenglish.net/blog/2023/08/10/spot-the-bug/
- https://mikeenglish.net/blog/2023/08/11/the-awaited-solution/